### PR TITLE
Fix undefined parameters rangeStart and rangeEnd

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ And finally emit your events to other components (if needed) (example):
      */
     public function onDatesSet(): void
     {
-        $this->emit('rangeSet', ['from' => $this->rangeStart->format('Y-m-d'), 'till' => $this->rangeEnd->format('Y-m-d')])
+        $this->emit('rangeSet', ['from' => $this->startRange->format('Y-m-d'), 'till' => $this->endRange->format('Y-m-d')])
     }
 
     /**


### PR DESCRIPTION
This is the code that is actually working for me. Seems that the documentation is a little bit off.

```
 $this->emit('rangeSet',
      [
            'from' => $this->startRange->format('Y-m-d'),
            'until' => $this->endRange->format('Y-m-d')
      ]
);
```